### PR TITLE
nodeuptime

### DIFF
--- a/nodeuptime
+++ b/nodeuptime
@@ -1,0 +1,31 @@
+!/usr/bin/awk -f
+function get_uptime(line, numfields)
+{
+  if ( line ~ /Uptime / )
+ {
+    totalSeconds = $numfields
+  ; remainingSeconds = totalSeconds % 60
+  ; hours = ( totalSeconds%86400) / 3600
+  ; days = (totalSeconds/86400)
+  ; minutes = (totalSeconds%3600)/60
+  ; printf("%d:Days %d:Hours %d:Minutes %d:Seconds\n",days,hours,minutes,remainingSeconds)
+  ; return 1
+ }
+}
+
+BEGIN {  done = 0 }
+
+{
+if ( FILENAME != prevf )
+{
+prevf=FILENAME
+done=0
+printf("----%s----\n",FILENAME)
+}
+if ( ! done )
+{
+done = get_uptime($0 , NF )
+}
+}
+
+END {}


### PR DESCRIPTION
nodeuptime uses the output from `nodetool info` to display the nodes 'uptime' in  Days / Hours / Minutes / Seconds .  The output in nodetool info is in seconds and makes for difficult reading :) 

Usage Example:

The following will display the uptime for all the nodes in a standard diagnostic . 

`nodeuptime diagdir/nodes/*/nodetool/info 
`
> ----nodes/172.25.118.101/nodetool/info----
> 5:Days 21:Hours 42:Minutes 18:Seconds
> ----nodes/172.25.118.103/nodetool/info----
> 5:Days 21:Hours 56:Minutes 41:Seconds
> ----nodes/172.25.124.61/nodetool/info----
> 0:Days 3:Hours 33:Minutes 5:Seconds
> ----nodes/172.25.124.69/nodetool/info----
> 0:Days 1:Hours 33:Minutes 31:Seconds
> ----nodes/172.25.124.73/nodetool/info----
> 0:Days 0:Hours 40:Minutes 51:Seconds

Or a single file:

`nodeuptime  nodetool/info`

> ----nodetool/info----
> 0:Days 3:Hours 11:Minutes 24:Seconds

Or pipe nodetool info to nodeuptime 

`nodetool info | nodeuptime`
>0:Days 3:Hours 11:Minutes 24:Seconds

